### PR TITLE
#patch Disabled text->binary resource conversion on export

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -94,6 +94,10 @@ window/stretch/mode="canvas_items"
 
 project/assembly_name="LD54"
 
+[editor]
+
+export/convert_text_resources_to_binary=false
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/dialogic/plugin.cfg", "res://addons/godot_state_charts/plugin.cfg", "res://addons/sound_manager/plugin.cfg")


### PR DESCRIPTION
This is a workaround to an existing issue with Godot not exporting shader parameters correctly when running in headless mode, breaking our starmap shaders when exported via CI/CD.

https://github.com/godotengine/godot/issues/66842
